### PR TITLE
Add multi-threading for stopping upnpservices

### DIFF
--- a/src/com/moxeja/uupnp/MappingEntry.java
+++ b/src/com/moxeja/uupnp/MappingEntry.java
@@ -40,39 +40,45 @@ public class MappingEntry {
 	}
 	
 	public void startUPnP() throws Exception, UnknownHostException {
-		if (upnpservice != null) {
+		synchronized (name) {
+			if (upnpservice != null) {
+				running = true;
+				return;
+			}
+			
+			// Get local IP
+			String internalIP;
+			internalIP = InetAddress.getLocalHost().getHostAddress();
+			
+			// Setup portmapping to use with upnpservice
+			PortMapping[] portList;
+			if (protocol == Protocols.UDP) {
+				portList = new PortMapping[] {new PortMapping(port, internalIP, PortMapping.Protocol.UDP, name)};
+			} else if (protocol == Protocols.TCP) {
+				portList = new PortMapping[] {new PortMapping(port, internalIP, PortMapping.Protocol.TCP, name)};
+			} else if (protocol == Protocols.UDP_TCP) {
+				portList = new PortMapping[] {new PortMapping(port, internalIP, PortMapping.Protocol.UDP, name),
+						new PortMapping(port, internalIP, PortMapping.Protocol.TCP, name)};
+			} else {
+				throw new Exception("Unknown Protocol Type: "+protocol);
+			}
+			
+			// Use Jetty implementation to stop errors
+			upnpservice = new UpnpServiceImpl(new JettyUPnPConfiguration(), new PortMappingListener(portList));
+			upnpservice.getControlPoint().search();
 			running = true;
-			return;
 		}
-		
-		// Get local IP
-		String internalIP;
-		internalIP = InetAddress.getLocalHost().getHostAddress();
-		
-		// Setup portmapping to use with upnpservice
-		PortMapping[] portList;
-		if (protocol == Protocols.UDP) {
-			portList = new PortMapping[] {new PortMapping(port, internalIP, PortMapping.Protocol.UDP, name)};
-		} else if (protocol == Protocols.TCP) {
-			portList = new PortMapping[] {new PortMapping(port, internalIP, PortMapping.Protocol.TCP, name)};
-		} else if (protocol == Protocols.UDP_TCP) {
-			portList = new PortMapping[] {new PortMapping(port, internalIP, PortMapping.Protocol.UDP, name),
-					new PortMapping(port, internalIP, PortMapping.Protocol.TCP, name)};
-		} else {
-			throw new Exception("Unknown Protocol Type: "+protocol);
-		}
-		
-		// Use Jetty implementation to stop errors
-		upnpservice = new UpnpServiceImpl(new JettyUPnPConfiguration(), new PortMappingListener(portList));
-		upnpservice.getControlPoint().search();
-		running = true;
 	}
 	
 	public void stopUPnP() {
-		if (upnpservice != null) {
-			upnpservice.shutdown();
-			upnpservice = null;
-			running = false;
+		if (upnpservice != null && running) {
+			new Thread(() -> {
+				synchronized (name) {
+					upnpservice.shutdown();
+					upnpservice = null;
+				}
+			}).start();
 		}
+		running = false;
 	}
 }

--- a/src/com/moxeja/uupnp/MappingList.java
+++ b/src/com/moxeja/uupnp/MappingList.java
@@ -25,8 +25,7 @@ public class MappingList {
 		if (id > entries.size() || id < 0)
 			return;
 		
-		Window.LOGGER.log(LogSeverity.INFO, "Stopping service with id: "+id);
-		entries.get(id).stopUPnP();
+		stopEntry(id);
 		
 		Window.LOGGER.log(LogSeverity.INFO, "Deleting service with id: "+id);
 		MappingEntry temp = entries.get(id);


### PR DESCRIPTION
From my testing, using a thread to handle the upnpservice shutdown speeds up the code significantly in scenarios where there are many mapping active and they all need to be shutdown at once.

An example of where this might be useful would be if the user had many mappings running and their OS forcibly restarted. The shutdown hook will be run and the upnpservices will be shutdown as fast as possible in parallel.

Time taken test:
* Single-Thread: 3700 ms
* Multi-Thread:	2 ms
